### PR TITLE
Add the possibility to customize the table name

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -35,7 +35,7 @@ export function Entity(name?: string | ModelOptions<any>, options?: ModelOptions
             meta.name = target.name;
 
             if (options == null && name != null && typeof name === 'object') {
-                options = Object.assign({}, { name: name }, meta.options);
+                options = Object.assign({}, name, meta.options);
             }
         }
 


### PR DESCRIPTION
I changed it because the way it was working before did not allow me to customize the table name like that:
```js
@Entity({ tableName: 'cities' })
class City {
    ...
}
```

The variable `meta.options` in the line 38 was getting like that: 
`{ name: { tableName: "cities" } }`
but I think the right way should be:
 `{ tableName: "cities" }`